### PR TITLE
Added stock type in admin new product page

### DIFF
--- a/lib/models/product_model.dart
+++ b/lib/models/product_model.dart
@@ -35,7 +35,7 @@ class Product {
   final String documentId;
   final bool isPublished;
   final Category category;
-  final List<Stock> stockList;
+  final Stock stock;
 
   Product({
     this.name,
@@ -46,11 +46,11 @@ class Product {
     this.documentId,
     this.isPublished,
     this.category,
-    this.stockList,
+    this.stock,
   });
 
   Map<String, dynamic> toMap() {
-    Map<String, dynamic> map = {
+    return {
       'name': name,
       'description': description,
       'priceInYen': priceInYen,
@@ -58,11 +58,8 @@ class Product {
       'created': created,
       'isPublished': isPublished,
       'category': category?.index,
+      'stock': stock.toMap(),
     };
-
-    map['stockList'] = stockList?.map((stock) => stock.toMap())?.toList();
-
-    return map;
   }
 
   Product.fromMap(Map<String, dynamic> map, String documentId)
@@ -75,10 +72,7 @@ class Product {
         isPublished = map['isPublished'],
         category =
             map['category'] != null ? Category.values[map['category']] : null,
-        stockList = map['stockList']
-            ?.map<Stock>(
-                (stock) => Stock.fromMap(stock.cast<String, dynamic>()))
-            ?.toList(),
+        stock = map['stock'] != null ? Stock.fromMap(map['stock'].cast<String, dynamic>()) : null,
         documentId = documentId;
 
   Product.fromSnapshot(DocumentSnapshot snapshot)

--- a/lib/models/stock_model.dart
+++ b/lib/models/stock_model.dart
@@ -84,7 +84,6 @@ String getDisplayTextForItemSize(ItemSize itemSize) {
   }
 }
 
-// TODO: Use StockIdentifier
 class StockItem {
   final ItemColor color;
   final ItemSize size;

--- a/lib/models/stock_model.dart
+++ b/lib/models/stock_model.dart
@@ -4,15 +4,32 @@ import 'package:flutter/material.dart';
 enum ItemColor {
   black,
   brown,
-  na,
   white,
 }
 
 enum ItemSize {
   large,
   medium,
-  na,
   small,
+}
+
+enum StockType {
+  sizeAndColor,
+  sizeOnly,
+  colorOnly,
+}
+
+String getDisplayTextForStockType(StockType stockType) {
+  switch (stockType) {
+    case StockType.colorOnly:
+      return "色のみ選択";
+    case StockType.sizeAndColor:
+      return "サイズと色を選択";
+    case StockType.sizeOnly:
+      return "サイズのみ選択";
+    default:
+      return "";
+  }
 }
 
 String getDisplayTextForItemColor(ItemColor itemColor) {
@@ -21,8 +38,6 @@ String getDisplayTextForItemColor(ItemColor itemColor) {
       return "ブラック";
     case ItemColor.brown:
       return "ブラウン";
-    case ItemColor.na:
-      return "無し";
     case ItemColor.white:
       return "ホワイト";
     default:
@@ -36,8 +51,6 @@ Color getDisplayColorForItemColor(ItemColor itemColor) {
       return paletteBlackColor;
     case ItemColor.brown:
       return paletteBrownColor;
-    case ItemColor.na:
-      return Colors.transparent;
     case ItemColor.white:
       return kPaletteWhite;
     default:
@@ -51,8 +64,6 @@ Color getDisplayTextColorForItemColor(ItemColor itemColor) {
       return kPaletteWhite;
     case ItemColor.brown:
       return kPaletteWhite;
-    case ItemColor.na:
-      return paletteGreyColor2;
     case ItemColor.white:
       return paletteGreyColor2;
     default:
@@ -66,13 +77,39 @@ String getDisplayTextForItemSize(ItemSize itemSize) {
       return "L";
     case ItemSize.medium:
       return "M";
-    case ItemSize.na:
-      return "x";
     case ItemSize.small:
       return "S";
     default:
       return "";
   }
+}
+
+// TODO: Use StockIdentifier
+class StockItem {
+  final ItemColor color;
+  final ItemSize size;
+  final int quantity;
+
+  StockItem({
+    this.color,
+    this.size,
+    this.quantity,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'color': color.index,
+      'size': size.index,
+      'quantity': quantity,
+    };
+  }
+
+  StockItem.fromMap(Map<String, dynamic> map)
+      : assert(map['color'] != null),
+        assert(map['size'] != null),
+        color = ItemColor.values[map['color']],
+        size = ItemSize.values[map['size']],
+        quantity = map['quantity'];
 }
 
 class StockIdentifier {
@@ -99,24 +136,25 @@ class StockIdentifier {
 }
 
 class Stock {
-  final StockIdentifier identifier;
-  final int quantity;
+  final List<StockItem> items;
+  final StockType stockType;
 
   Stock({
-    this.identifier,
-    this.quantity,
+    this.items,
+    this.stockType,
   });
 
   Map<String, dynamic> toMap() {
     return {
-      'identifier': identifier.toMap(),
-      'quantity': quantity,
+      'items': items?.map((item) => item.toMap())?.toList(),
+      'stockType': stockType.index,
     };
   }
 
   Stock.fromMap(Map<String, dynamic> map)
-      : identifier = StockIdentifier.fromMap(
-          map['identifier'].cast<String, dynamic>(),
-        ),
-        quantity = map['quantity'];
+      : items = map['items']
+            ?.map<StockItem>(
+                (stock) => StockItem.fromMap(stock.cast<String, dynamic>()))
+            ?.toList(),
+        stockType = StockType.values[map['stockType']];
 }

--- a/lib/screens/admin_new_product_page.dart
+++ b/lib/screens/admin_new_product_page.dart
@@ -105,13 +105,18 @@ class _AdminNewProductPageState extends State<AdminNewProductPage> {
       }
 
       _productCategory = _product.category;
-      _productStockType = _product.stock.stockType;
 
-      _product.stock.items.forEach((stock) {
-        _productStockMap.putIfAbsent(
-            StockIdentifier(color: stock.color, size: stock.size),
-            () => stock.quantity);
-      });
+      if (_product.stock != null) {
+        _productStockType = _product.stock.stockType;
+
+        _product.stock.items.forEach((stock) {
+          _productStockMap.putIfAbsent(
+              StockIdentifier(color: stock.color, size: stock.size),
+              () => stock.quantity);
+        });
+      } else {
+        _productStockType = StockType.sizeAndColor;
+      }
 
       _productPublishStatus =
           _product.isPublished ? PublishStatus.Published : PublishStatus.Draft;

--- a/lib/screens/admin_new_product_page.dart
+++ b/lib/screens/admin_new_product_page.dart
@@ -568,10 +568,8 @@ class _AdminNewProductPageState extends State<AdminNewProductPage> {
         ),
         onPressed: () async {
           setState(() {
-            _productStockMap.remove(StockIdentifier(
-              color: stockItem.color,
-              size: stockItem.size,
-            ));
+            _productStockMap.removeWhere((key, q) =>
+                key.color == stockItem.color && key.size == stockItem.size);
           });
           Navigator.pop(context);
         },

--- a/lib/widgets/stock_selector.dart
+++ b/lib/widgets/stock_selector.dart
@@ -3,27 +3,29 @@ import 'package:badiup/models/stock_model.dart';
 import 'package:flutter/material.dart';
 
 class StockSelector extends StatefulWidget {
-  StockSelector({Key key, this.productStock}) : super(key: key);
+  StockSelector({Key key, this.productStockItem, this.productStockType})
+      : super(key: key);
 
-  final Stock productStock;
+  final StockItem productStockItem;
+  final StockType productStockType;
 
   @override
   _StockSelectorState createState() => _StockSelectorState();
 }
 
 class _StockSelectorState extends State<StockSelector> {
-  ItemSize _stockSize = ItemSize.na;
-  ItemColor _stockColor = ItemColor.na;
+  ItemSize _stockSize = ItemSize.small;
+  ItemColor _stockColor = ItemColor.black;
   var _stockQuantityEditingController = TextEditingController();
 
   @override
   initState() {
     super.initState();
-    if (widget.productStock != null) {
-      _stockSize = widget.productStock.identifier.size;
-      _stockColor = widget.productStock.identifier.color;
+    if (widget.productStockItem != null) {
+      _stockSize = widget.productStockItem.size;
+      _stockColor = widget.productStockItem.color;
       _stockQuantityEditingController.text =
-          widget.productStock.quantity.toString();
+          widget.productStockItem.quantity.toString();
     }
   }
 
@@ -39,22 +41,40 @@ class _StockSelectorState extends State<StockSelector> {
       fontWeight: FontWeight.w600,
     );
 
+    var widgetList = List<Widget>();
+
+    if (widget.productStockType == StockType.sizeAndColor ||
+        widget.productStockType == StockType.sizeOnly) {
+      widgetList.add(_buildStockSize(_textStyle));
+    }
+
+    if (widget.productStockType == StockType.sizeAndColor ||
+        widget.productStockType == StockType.colorOnly) {
+      widgetList.add(_buildStockColor(_textStyle));
+    }
+
+    widgetList.add(_buildStockQuantityPicker());
+    widgetList.add(_buildStockFormActionButtons());
+
     return Padding(
       padding: EdgeInsets.all(16),
       child: Column(
         mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          widget.productStock == null
-              ? _buildStockSizePicker(_textStyle)
-              : _buildStockSizeDisplay(_textStyle),
-          widget.productStock == null
-              ? _buildStockColorPicker(_textStyle)
-              : _buildStockColorDisplay(_textStyle),
-          _buildStockQuantityPicker(),
-          _buildStockFormActionButtons(),
-        ],
+        children: widgetList,
       ),
     );
+  }
+
+  Widget _buildStockColor(TextStyle _textStyle) {
+    return widget.productStockItem == null
+        ? _buildStockColorPicker(_textStyle)
+        : _buildStockColorDisplay(_textStyle);
+  }
+
+  Widget _buildStockSize(TextStyle _textStyle) {
+    return widget.productStockItem == null
+        ? _buildStockSizePicker(_textStyle)
+        : _buildStockSizeDisplay(_textStyle);
   }
 
   Widget _buildStockColorDisplay(TextStyle textStyle) {
@@ -113,8 +133,9 @@ class _StockSelectorState extends State<StockSelector> {
       onTap: () {
         Navigator.pop(
           context,
-          Stock(
-            identifier: StockIdentifier(color: _stockColor, size: _stockSize),
+          StockItem(
+            color: _stockColor,
+            size: _stockSize,
             quantity: int.tryParse(_stockQuantityEditingController.text) ?? 0,
           ),
         );
@@ -149,7 +170,7 @@ class _StockSelectorState extends State<StockSelector> {
     return _buildPicker<ItemColor>(
       pickerValue: _stockColor,
       textStyle: _textStyle,
-      valueOnChanged: widget.productStock == null
+      valueOnChanged: widget.productStockItem == null
           ? (ItemColor newValue) {
               setState(() {
                 _stockColor = newValue;
@@ -193,7 +214,7 @@ class _StockSelectorState extends State<StockSelector> {
     return _buildPicker<ItemSize>(
       pickerValue: _stockSize,
       textStyle: _textStyle,
-      valueOnChanged: widget.productStock == null
+      valueOnChanged: widget.productStockItem == null
           ? (ItemSize newValue) {
               setState(() {
                 _stockSize = newValue;


### PR DESCRIPTION
Fixes https://github.com/GospelAid/badiup/issues/116
Demo video: https://youtu.be/pPdAw9r-JMA

Note: 
1. Once a stock has been added, the stock type becomes locked - it can't be changed anymore. It will be unlocked when all the existing stocks are deleted. The idea: stocks of different types cannot coexist. 
2. Stock tile display changes according to stock type selected.

<img width="444" alt="Screen Shot 2020-02-21 at 17 08 03" src="https://user-images.githubusercontent.com/1173819/75016798-22618000-54cf-11ea-9937-2fc5b03e354b.png">
<img width="444" alt="Screen Shot 2020-02-21 at 17 07 55" src="https://user-images.githubusercontent.com/1173819/75016805-268d9d80-54cf-11ea-9011-a3293be35b46.png">
