### PR TITLE
Added missing items dialog and fixed the improper aspect ratio issue

### DIFF
--- a/lib/screens/admin_new_product_page.dart
+++ b/lib/screens/admin_new_product_page.dart
@@ -753,10 +753,12 @@ class _AdminNewProductPageState extends State<AdminNewProductPage> {
     return Switch(
       value: _productPublishStatus == PublishStatus.Published,
       onChanged: (value) {
-        setState(() {
-          _productPublishStatus =
-              value ? PublishStatus.Published : PublishStatus.Draft;
-        });
+        if (_formIsValid()) {
+          setState(() {
+            _productPublishStatus =
+                value ? PublishStatus.Published : PublishStatus.Draft;
+          });
+        }
       },
       activeTrackColor: paletteForegroundColor,
       activeColor: kPaletteWhite,
@@ -885,7 +887,6 @@ class _AdminNewProductPageState extends State<AdminNewProductPage> {
           : FadeInImage.memoryNetwork(
               fit: BoxFit.contain,
               placeholder: kTransparentImage,
-              height: constants.imageHeight,
               image: _productImages[_indexOfImageInDisplay] as String,
             );
     }
@@ -1130,7 +1131,7 @@ class _AdminNewProductPageState extends State<AdminNewProductPage> {
       ),
       validator: (value) {
         if (value.isEmpty) {
-          return 'Description cannot be empty';
+          return '説明が入力されていません';
         }
         return null;
       },
@@ -1169,9 +1170,6 @@ class _AdminNewProductPageState extends State<AdminNewProductPage> {
           labelStyle: TextStyle(fontSize: 16.0),
         ),
         validator: (value) {
-          if (value.isEmpty) {
-            return 'Price cannot be empty';
-          }
           return null;
         },
       ),
@@ -1209,7 +1207,7 @@ class _AdminNewProductPageState extends State<AdminNewProductPage> {
       maxLength: 20,
       validator: (value) {
         if (value.isEmpty) {
-          return 'Name cannot be empty';
+          return 'タイトルが入力されていません';
         }
         return null;
       },
@@ -1427,25 +1425,38 @@ class _AdminNewProductPageState extends State<AdminNewProductPage> {
   }
 
   bool _formIsValid() {
+    bool _result = _formKey.currentState.validate();
+
+    String _message = "";
+
     if (_productImages.length == 0) {
-      _buildImageMandatoryDialog();
-      return false;
+      _message += '写真　';
     }
 
-    return _formKey.currentState.validate();
+    if (_priceEditingController.text.isEmpty) {
+      _message += '値段　';
+    }
+
+    if (_message != "") {
+      _message += "が入力されていません。編集画面に戻って入力してください。";
+      _buildRequiredItemsMissingDialog(_message);
+      _result = false;
+    }
+
+    return _result;
   }
 
-  void _buildImageMandatoryDialog() {
+  void _buildRequiredItemsMissingDialog(String message) {
     showDialog<void>(
       context: context,
       barrierDismissible: true,
       builder: (BuildContext context) {
         return AlertDialog(
           title: Text(
-            'Image Required!',
+            '入力されていない項目があります',
             style: getAlertStyle(),
           ),
-          content: Text('Please upload an image'),
+          content: Text(message),
           actions: <Widget>[
             FlatButton(
               child: Text('OK'),


### PR DESCRIPTION
Tapping on publish button in add new or edit product page would display dialogs if any required fields are empty. 

Fixes https://github.com/GospelAid/badiup/issues/58
Fixes https://github.com/GospelAid/badiup/issues/126

<img width="444" alt="Screen Shot 2020-02-21 at 23 11 08" src="https://user-images.githubusercontent.com/1173819/75042019-1989a200-5501-11ea-9cc4-b47eedc7c150.png">
<img width="444" alt="Screen Shot 2020-02-21 at 23 11 31" src="https://user-images.githubusercontent.com/1173819/75042030-1d1d2900-5501-11ea-93b0-6266082e177a.png">
<img width="444" alt="Screen Shot 2020-02-21 at 23 11 52" src="https://user-images.githubusercontent.com/1173819/75042033-1db5bf80-5501-11ea-8d93-8f6a660a54fd.png">

Also fixed the improper aspect ratio issue in Edit product page:

<img width="444" alt="Screen Shot 2020-02-21 at 23 18 59" src="https://user-images.githubusercontent.com/1173819/75042095-37570700-5501-11ea-95f8-a33cbfa17e51.png">

