### PR TITLE
Added size and color support in customer product detail and cart pages

### DIFF
--- a/lib/models/cart_model.dart
+++ b/lib/models/cart_model.dart
@@ -1,3 +1,5 @@
+import 'package:badiup/models/stock_model.dart';
+
 class Cart {
   List<CartItem> items;
 
@@ -21,23 +23,24 @@ class Cart {
 
 class CartItem {
   String productDocumentId;
-  int quantity;
+  StockItem stockRequest;
 
   CartItem({
     this.productDocumentId,
-    this.quantity,
+    this.stockRequest,
   });
 
   Map<String, dynamic> toMap() {
     return {
       'productDocumentId': productDocumentId,
-      'quantity': quantity,
+      'stockRequest': stockRequest.toMap(),
     };
   }
 
   CartItem.fromMap(Map<String, dynamic> map)
       : assert(map['productDocumentId'] != null),
-        assert(map['quantity'] != null),
         productDocumentId = map['productDocumentId'],
-        quantity = map['quantity'];
+        stockRequest = map['stockRequest'] != null
+            ? StockItem.fromMap(map['stockRequest'].cast<String, dynamic>())
+            : null;
 }

--- a/lib/models/customer_model.dart
+++ b/lib/models/customer_model.dart
@@ -1,9 +1,8 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-
-import 'package:badiup/models/cart.dart';
+import 'package:badiup/models/cart_model.dart';
 import 'package:badiup/models/user_model.dart';
 import 'package:badiup/models/user_setting_model.dart';
 import 'package:badiup/models/address_model.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Customer extends User {
   List<Address> shippingAddresses;

--- a/lib/models/order_model.dart
+++ b/lib/models/order_model.dart
@@ -1,7 +1,8 @@
+import 'package:badiup/models/stock_model.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:uuid/uuid.dart';
 
-class Order{
+class Order {
   final String documentId;
   final String customerId;
   final List<OrderItem> items;
@@ -23,9 +24,7 @@ class Order{
   });
 
   double getOrderPrice() {
-    return items.map(
-      (item) => item.price
-    ).reduce( (a, b) => a + b );
+    return items.map((item) => item.price).reduce((a, b) => a + b);
   }
 
   String getOrderStatusText() {
@@ -48,61 +47,61 @@ class Order{
       'trackingUrl': trackingUrl,
       'orderId': orderId,
     };
-    map['items'] = items.map(
-      (item) => item.toMap()
-    ).toList();
+    map['items'] = items.map((item) => item.toMap()).toList();
 
     return map;
   }
 
   Order.fromMap(Map<String, dynamic> map, String documentId)
-    : customerId = map['customerId'],
-      status = OrderStatus.values[ map['status'] ],
-      placedDate = map['placedDate'].toDate(),
-      details = map['details'],
-      trackingUrl = map['trackingUrl'],
-      items = map['items'].map<OrderItem>(
-        (item) => OrderItem.fromMap( item.cast<String, dynamic>() )
-      ).toList(),
-      documentId = documentId,
-      orderId = map['orderId'];
+      : customerId = map['customerId'],
+        status = OrderStatus.values[map['status']],
+        placedDate = map['placedDate'].toDate(),
+        details = map['details'],
+        trackingUrl = map['trackingUrl'],
+        items = map['items']
+            .map<OrderItem>(
+                (item) => OrderItem.fromMap(item.cast<String, dynamic>()))
+            .toList(),
+        documentId = documentId,
+        orderId = map['orderId'];
 
   Order.fromSnapshot(DocumentSnapshot snapshot)
-    : this.fromMap(snapshot.data, snapshot.documentID);
+      : this.fromMap(snapshot.data, snapshot.documentID);
 
   static String generateOrderId() {
     return Uuid().v4().substring(0, 6).toUpperCase();
   }
 }
 
-class OrderItem{
+class OrderItem {
   String productId;
-  int quantity;
+  StockItem stockRequest;
   double price;
 
   OrderItem({
     this.productId,
-    this.quantity,
+    this.stockRequest,
     this.price,
   });
 
   Map<String, dynamic> toMap() {
     return {
       'productId': productId,
-      'quantity': quantity,
+      'stockRequest': stockRequest.toMap(),
       'price': price,
     };
   }
 
   OrderItem.fromMap(Map<String, dynamic> map)
-    : assert(map['productId'] != null),
-      assert(map['quantity'] != null),
-      productId = map['productId'],
-      quantity = map['quantity'],
-      price = map['price'];
+      : assert(map['productId'] != null),
+        productId = map['productId'],
+        stockRequest = map['stockRequest'] != null
+            ? StockItem.fromMap(map['stockRequest'].cast<String, dynamic>())
+            : null,
+        price = map['price'];
 }
 
-enum OrderStatus{
+enum OrderStatus {
   all,
   pending,
   dispatched,

--- a/lib/models/stock_model.dart
+++ b/lib/models/stock_model.dart
@@ -87,7 +87,7 @@ String getDisplayTextForItemSize(ItemSize itemSize) {
 class StockItem {
   final ItemColor color;
   final ItemSize size;
-  final int quantity;
+  int quantity;
 
   StockItem({
     this.color,
@@ -97,17 +97,15 @@ class StockItem {
 
   Map<String, dynamic> toMap() {
     return {
-      'color': color.index,
-      'size': size.index,
+      'color': color?.index,
+      'size': size?.index,
       'quantity': quantity,
     };
   }
 
   StockItem.fromMap(Map<String, dynamic> map)
-      : assert(map['color'] != null),
-        assert(map['size'] != null),
-        color = ItemColor.values[map['color']],
-        size = ItemSize.values[map['size']],
+      : color = map['color'] != null ? ItemColor.values[map['color']] : null,
+        size = map['size'] != null ? ItemSize.values[map['size']] : null,
         quantity = map['quantity'];
 }
 
@@ -119,19 +117,6 @@ class StockIdentifier {
     this.color,
     this.size,
   });
-
-  Map<String, dynamic> toMap() {
-    return {
-      'color': color.index,
-      'size': size.index,
-    };
-  }
-
-  StockIdentifier.fromMap(Map<String, dynamic> map)
-      : assert(map['color'] != null),
-        assert(map['size'] != null),
-        color = ItemColor.values[map['color']],
-        size = ItemSize.values[map['size']];
 }
 
 class Stock {

--- a/lib/screens/admin_new_product_page.dart
+++ b/lib/screens/admin_new_product_page.dart
@@ -241,7 +241,7 @@ class _AdminNewProductPageState extends State<AdminNewProductPage> {
     widgetList.add(form);
 
     if (_formSubmitInProgress) {
-      widgetList.add(_buildFormSubmitInProgressIndicator());
+      widgetList.add(buildFormSubmitInProgressIndicator());
     }
 
     return Stack(
@@ -266,24 +266,6 @@ class _AdminNewProductPageState extends State<AdminNewProductPage> {
         ),
       ),
     );
-  }
-
-  Widget _buildFormSubmitInProgressIndicator() {
-    var modal = Stack(
-      children: [
-        Opacity(
-          opacity: 0.5,
-          child: const ModalBarrier(
-            dismissible: false,
-            color: Colors.black,
-          ),
-        ),
-        Center(
-          child: CircularProgressIndicator(),
-        ),
-      ],
-    );
-    return modal;
   }
 
   List<Widget> _buildFormFields(BuildContext context) {

--- a/lib/screens/customer_product_detail_page.dart
+++ b/lib/screens/customer_product_detail_page.dart
@@ -1,8 +1,9 @@
 import 'package:badiup/colors.dart';
 import 'package:badiup/constants.dart' as constants;
-import 'package:badiup/models/cart.dart';
+import 'package:badiup/models/cart_model.dart';
 import 'package:badiup/models/customer_model.dart';
 import 'package:badiup/models/product_model.dart';
+import 'package:badiup/models/stock_model.dart';
 import 'package:badiup/screens/cart_page.dart';
 import 'package:badiup/sign_in.dart';
 import 'package:badiup/widgets/cart_button.dart';
@@ -29,6 +30,9 @@ class _CustomerProductDetailPageState extends State<CustomerProductDetailPage> {
 
   QuantityController quantityController = QuantityController(value: 1);
 
+  ItemSize _selectedItemSize;
+  ItemColor _selectedItemColor;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -45,6 +49,7 @@ class _CustomerProductDetailPageState extends State<CustomerProductDetailPage> {
         ListView(
           children: <Widget>[
             ProductDetail(productDocumentId: widget.productDocumentId),
+            _buildStockSelector(),
             SizedBox(height: 150),
           ],
         ),
@@ -57,6 +62,190 @@ class _CustomerProductDetailPageState extends State<CustomerProductDetailPage> {
         ),
       ],
     );
+  }
+
+  Widget _buildStockSelector() {
+    return StreamBuilder<DocumentSnapshot>(
+      stream: Firestore.instance
+          .collection(constants.DBCollections.products)
+          .document(widget.productDocumentId)
+          .snapshots(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return LinearProgressIndicator();
+        }
+
+        return _buildStockSelectorInternal(
+          Product.fromSnapshot(snapshot.data),
+          TextStyle(
+            color: paletteBlackColor,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildStockSelectorInternal(Product _product, TextStyle _textStyle) {
+    List<Widget> _widgetList = [];
+
+    if (_product.stock.stockType == StockType.sizeAndColor ||
+        _product.stock.stockType == StockType.sizeOnly) {
+      _widgetList.add(_buildStockSizePicker(_product.stock, _textStyle));
+    }
+
+    if (_product.stock.stockType == StockType.sizeAndColor) {
+      _widgetList.add(SizedBox(height: 12));
+    }
+
+    if (_product.stock.stockType == StockType.sizeAndColor ||
+        _product.stock.stockType == StockType.colorOnly) {
+      _widgetList.add(_buildStockColorPicker(_product.stock, _textStyle));
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Column(children: _widgetList),
+    );
+  }
+
+  Widget _buildStockColorPicker(Stock stock, TextStyle textStyle) {
+    return Container(
+      alignment: AlignmentDirectional.centerStart,
+      height: 67,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(5),
+        color: kPaletteWhite,
+      ),
+      child: _buildStockColorPickerButton(stock, textStyle),
+    );
+  }
+
+  Widget _buildStockColorPickerButton(Stock stock, TextStyle textStyle) {
+    var _availableStockColors = _getAvailableStockColors(stock);
+
+    _selectedItemColor ??= _availableStockColors.first;
+
+    return DropdownButton<ItemColor>(
+      value: _selectedItemColor,
+      focusColor: paletteBlackColor,
+      isExpanded: true,
+      icon: _buildDropdownButtonIcon(),
+      iconSize: 32,
+      elevation: 2,
+      style: textStyle,
+      underline: Container(),
+      onChanged: (ItemColor newValue) {
+        setState(() {
+          _selectedItemColor = newValue;
+        });
+      },
+      items: _availableStockColors
+          .map<DropdownMenuItem<ItemColor>>((ItemColor value) {
+        return DropdownMenuItem<ItemColor>(
+          value: value,
+          child: _buildDropdownMenuItem(
+            "色：",
+            getDisplayTextForItemColor(value),
+            textStyle,
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildDropdownMenuItem(
+    String text1,
+    String text2,
+    TextStyle textStyle,
+  ) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      alignment: AlignmentDirectional.centerStart,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          Text(text1, style: TextStyle(fontWeight: FontWeight.w300)),
+          Text(text2, style: textStyle),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStockSizePickerButton(Stock stock, TextStyle textStyle) {
+    var _availableStockSizes = _getAvailableStockSizes(stock);
+
+    _selectedItemSize ??= _availableStockSizes.first;
+
+    return DropdownButton<ItemSize>(
+      value: _selectedItemSize,
+      focusColor: paletteBlackColor,
+      isExpanded: true,
+      icon: _buildDropdownButtonIcon(),
+      iconSize: 32,
+      elevation: 2,
+      style: textStyle,
+      underline: Container(),
+      onChanged: (ItemSize newValue) {
+        setState(() {
+          _selectedItemSize = newValue;
+        });
+      },
+      items: _availableStockSizes
+          .map<DropdownMenuItem<ItemSize>>((ItemSize value) {
+        return DropdownMenuItem<ItemSize>(
+          value: value,
+          child: _buildDropdownMenuItem(
+            "サイズ：",
+            getDisplayTextForItemSize(value),
+            textStyle,
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildDropdownButtonIcon() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Icon(Icons.keyboard_arrow_down, color: paletteDarkGreyColor),
+    );
+  }
+
+  Widget _buildStockSizePicker(Stock stock, TextStyle textStyle) {
+    return Container(
+      alignment: AlignmentDirectional.centerStart,
+      height: 67,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(5),
+        color: kPaletteWhite,
+      ),
+      child: _buildStockSizePickerButton(stock, textStyle),
+    );
+  }
+
+  List<ItemSize> _getAvailableStockSizes(Stock stock) {
+    var _availableStockSizes = _selectedItemColor != null
+        ? stock.items.where((stockItem) =>
+            stockItem.quantity != 0 && stockItem.color == _selectedItemColor)
+        : stock.items.where((stockItem) => stockItem.quantity != 0);
+    return _availableStockSizes
+        .map<ItemSize>((stockItem) => stockItem.size)
+        .toSet()
+        .toList();
+  }
+
+  List<ItemColor> _getAvailableStockColors(Stock stock) {
+    var _availableStockColors = _selectedItemSize != null
+        ? stock.items.where((stockItem) =>
+            stockItem.quantity != 0 && stockItem.size == _selectedItemSize)
+        : stock.items.where((stockItem) => stockItem.quantity != 0);
+    return _availableStockColors
+        .map<ItemColor>((stockItem) => stockItem.color)
+        .toSet()
+        .toList();
   }
 
   Widget _buildQuantitySelector() {
@@ -130,7 +319,13 @@ class _CustomerProductDetailPageState extends State<CustomerProductDetailPage> {
   Widget _buildAddToCartButton() {
     return Expanded(
       child: GestureDetector(
-        onTap: _addToCart,
+        onTap: () {
+          _addToCart();
+
+          _scaffoldKey.currentState.showSnackBar(
+            _buildAddedToCartNotification(),
+          );
+        },
         child: Container(
           height: 64,
           color: paletteForegroundColor,
@@ -155,6 +350,22 @@ class _CustomerProductDetailPageState extends State<CustomerProductDetailPage> {
     );
   }
 
+  SnackBar _buildAddedToCartNotification() {
+    return SnackBar(
+      behavior: SnackBarBehavior.fixed,
+      content: Container(
+        alignment: AlignmentDirectional.centerStart,
+        height: 40,
+        child: Text("商品をかごに追加しました"),
+      ),
+      action: SnackBarAction(
+        textColor: paletteGreyColor3,
+        label: "OK",
+        onPressed: () {},
+      ),
+    );
+  }
+
   Future<void> _addToCart() async {
     var customer = Customer.fromSnapshot(await db
         .collection(constants.DBCollections.users)
@@ -167,45 +378,37 @@ class _CustomerProductDetailPageState extends State<CustomerProductDetailPage> {
         .collection(constants.DBCollections.users)
         .document(currentSignedInUser.email)
         .updateData(customer.toMap());
-
-    _scaffoldKey.currentState.showSnackBar(
-      SnackBar(
-        behavior: SnackBarBehavior.fixed,
-        content: Container(
-          alignment: AlignmentDirectional.centerStart,
-          height: 40,
-          child: Text("商品をかごに追加しました"),
-        ),
-        action: SnackBarAction(
-          textColor: paletteGreyColor3,
-          label: "OK",
-          onPressed: () {},
-        ),
-      ),
-    );
   }
 
   void _updateCartModel(Customer customer) {
+    var _stockRequest = StockItem(
+      color: _selectedItemColor,
+      size: _selectedItemSize,
+      quantity: quantityController.quantity,
+    );
+
     if (customer.cart == null) {
       customer.cart = Cart(
         items: [
           CartItem(
             productDocumentId: widget.productDocumentId,
-            quantity: quantityController.quantity,
+            stockRequest: _stockRequest,
           ),
         ],
       );
     } else {
-      int productIndex = customer.cart.items.indexWhere(
-          (item) => item.productDocumentId == widget.productDocumentId);
+      int productIndex = customer.cart.items.indexWhere((cartItem) =>
+          cartItem.productDocumentId == widget.productDocumentId &&
+          cartItem.stockRequest?.color == _selectedItemColor &&
+          cartItem.stockRequest?.size == _selectedItemSize);
 
       if (productIndex != -1) {
-        customer.cart.items[productIndex].quantity +=
+        customer.cart.items[productIndex].stockRequest.quantity +=
             quantityController.quantity;
       } else {
         customer.cart.items.add(CartItem(
           productDocumentId: widget.productDocumentId,
-          quantity: quantityController.quantity,
+          stockRequest: _stockRequest,
         ));
       }
     }

--- a/lib/utilities.dart
+++ b/lib/utilities.dart
@@ -20,3 +20,20 @@ Widget buildIconWithShadow(IconData iconData, {double iconSize = 24.0}) {
     ],
   );
 }
+
+Widget buildFormSubmitInProgressIndicator() {
+  return Stack(
+    children: [
+      Opacity(
+        opacity: 0.5,
+        child: const ModalBarrier(
+          dismissible: false,
+          color: Colors.black,
+        ),
+      ),
+      Center(
+        child: CircularProgressIndicator(),
+      ),
+    ],
+  );
+}

--- a/lib/widgets/cart_button.dart
+++ b/lib/widgets/cart_button.dart
@@ -71,7 +71,8 @@ class CartButton extends StatelessWidget {
         var customer = Customer.fromSnapshot(snapshot.data);
         int itemCount = (customer.cart == null)
             ? 0
-            : customer.cart.items.fold(0, (a, b) => a + b.quantity);
+            : customer.cart.items
+                .fold(0, (a, b) => a + (b.stockRequest?.quantity ?? 0));
 
         return Text(
           itemCount.toString(),

--- a/lib/widgets/product_detail.dart
+++ b/lib/widgets/product_detail.dart
@@ -218,8 +218,6 @@ class _ProductDetailState extends State<ProductDetail> {
   Widget _buildProductListingItemTileImage(Product product) {
     return Container(
       color: paletteDarkGreyColor,
-      height: constants.imageHeight,
-      width: 500,
       child: _getProductListingImage(product),
     );
   }
@@ -255,7 +253,6 @@ class _ProductDetailState extends State<ProductDetail> {
       productImage = FadeInImage.memoryNetwork(
         fit: BoxFit.contain,
         placeholder: kTransparentImage,
-        height: constants.imageHeight,
         image: product.imageUrls[_indexOfImageInDisplay],
       );
     }

--- a/lib/widgets/product_listing.dart
+++ b/lib/widgets/product_listing.dart
@@ -82,11 +82,15 @@ class _ProductListingState extends State<ProductListing> {
     int index,
   ) {
     final product = Product.fromSnapshot(data);
+    int _productQuantity = (product.stock == null)
+        ? 0
+        : product.stock.items.fold(0, (a, b) => a + (b?.quantity ?? 0));
 
     // Show only published products if current user is customer
     // Otherwise, show all products
     if (!(currentSignedInUser.role == RoleType.customer &&
-        !product.isPublished)) {
+            !product.isPublished) &&
+        _productQuantity > 0) {
       // If no category filters are selected, show all products
       if (_categoryFilters.isEmpty ||
           // If one of more category filters are selected, show all products that match the filters


### PR DESCRIPTION
This PR enables customer to place an order while customizing the size and/or color of the product. Products can belong to one of three categories, called stock type: 
1. Both size and color
2. Size only
3. Color only
Admin sets the stock type for the product during the create or update step. A product can have stocks belonging to only one stock type at any given time. 
When an order is successfully placed, the corresponding stock is subtracted from product db. 
The exact stock requested is available in the order model as well, for the admin to see in the order detail page.

Demo: https://youtu.be/AamUrbkSxOM

Fixes https://github.com/GospelAid/badiup/issues/127
Fixes https://github.com/GospelAid/badiup/issues/109
Fixes https://github.com/GospelAid/badiup/issues/124