### PR TITLE
[Color/Admin] Ability to add new colors and sizes #162

### DIFF
--- a/lib/colors.dart
+++ b/lib/colors.dart
@@ -33,3 +33,14 @@ TextStyle getAlertStyle() {
     fontWeight: FontWeight.bold,
   );
 }
+
+TextStyle getTextStyleWithHex(hex) {
+  return TextStyle(
+    color: Color(int.parse(hex)),
+    fontWeight: FontWeight.w600,
+  );
+}
+
+Color getColorWithHex(hex) {
+  return Color(int.parse(hex));
+}

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -8,6 +8,7 @@ class DBCollections {
   static const String products = "products";
   static const String orders = "orders";
   static const String texts = "texts";
+  static const String colors = "colors";
 }
 
 class StorageCollections {

--- a/lib/models/custom_color_model.dart
+++ b/lib/models/custom_color_model.dart
@@ -1,0 +1,84 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import 'package:badiup/colors.dart';
+
+class CustomColor {
+  final String name;
+  final String hex;
+  final String label;
+  final String textColor;
+  final DocumentReference reference;
+
+  CustomColor({
+    this.name,
+    this.hex,
+    this.label,
+    this.textColor,
+    this.reference,
+  });
+
+  CustomColor.fromMap(Map<String, dynamic> map, {this.reference})
+      : assert(map['name'] != null),
+        assert(map['hex'] != null),
+        assert(map['label'] != null),
+        assert(map['textColor'] != null),
+        name = map['name'].trim(), //TODO: reseach a reason for the space to be included automatically
+        hex = map['hex'].trim(),
+        label = map['label'].trim(),
+        textColor = map['textColor'].trim();
+
+  CustomColor.fromSnapshot(DocumentSnapshot snapshot)
+      : this.fromMap(snapshot.data, reference: snapshot.reference);
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'hex': hex,
+      'label': label,
+      'textColor': textColor,
+    };
+  }
+
+  @override
+  String toString() => "CustomColor<$name:$hex:$label:$textColor>";
+}
+
+class CustomColorList {
+  final List<CustomColor> customColorList;
+  Map<String, CustomColor> customColorMap = {};
+  Map<String, Color> textColorMap = {
+    "grey": paletteGreyColor2,
+    "white": kPaletteWhite
+  };
+
+  CustomColorList({
+    this.customColorList,
+  });
+
+  void updateCustomColorMap() {
+    this.customColorList.forEach((color) => customColorMap[color.name] = color);
+  }
+
+  String getDisplayTextForItemColor(String colorName) {
+    updateCustomColorMap();
+    return customColorMap[colorName] == null
+        ? ""
+        : customColorMap[colorName].label;
+  }
+
+  Color getDisplayColorForItemColor(String colorName) {
+    updateCustomColorMap();
+    return customColorMap[colorName] == null
+        ? Colors.transparent
+        : getColorWithHex(customColorMap
+        [colorName].hex);
+  }
+
+  Color getDisplayTextColorForItemColor(String colorName) {
+    updateCustomColorMap();
+    return customColorMap[colorName] == null
+        ? paletteGreyColor2
+        : textColorMap[customColorMap[colorName].textColor];
+  }
+}

--- a/lib/models/stock_model.dart
+++ b/lib/models/stock_model.dart
@@ -1,6 +1,7 @@
 import 'package:badiup/colors.dart';
 import 'package:flutter/material.dart';
 
+//TOREMOVE: remove ItemColor once custom color model is integrated in both admin and customer pages. 
 enum ItemColor {
   black,
   brown,
@@ -40,54 +41,21 @@ String getDisplayTextForStockType(StockType stockType) {
   }
 }
 
-String getDisplayTextForItemColor(ItemColor itemColor) {
-  switch (itemColor) {
-    case ItemColor.black:
+//TOREMOVE: remove getDisplayTextForItemColor once custom color model is integrated in both admin and customer pages. 
+String getDisplayTextForItemColor(String colorName) {
+  switch (colorName) {
+    case "black":
       return "ブラック";
-    case ItemColor.brown:
+    case "brown":
       return "ブラウン";
-    case ItemColor.white:
+    case "white":
       return "ホワイト";
-    case ItemColor.pink:
+    case "pink":
       return "ピンク";
-    case ItemColor.grey:
+    case "grey":
       return "グレー";
     default:
       return "";
-  }
-}
-
-Color getDisplayColorForItemColor(ItemColor itemColor) {
-  switch (itemColor) {
-    case ItemColor.black:
-      return paletteBlackColor;
-    case ItemColor.brown:
-      return paletteBrownColor;
-    case ItemColor.white:
-      return kPaletteWhite;
-    case ItemColor.pink:
-      return kPalettePurple100;
-    case ItemColor.grey:
-      return paletteGreyColor;
-    default:
-      return Colors.transparent;
-  }
-}
-
-Color getDisplayTextColorForItemColor(ItemColor itemColor) {
-  switch (itemColor) {
-    case ItemColor.black:
-      return kPaletteWhite;
-    case ItemColor.brown:
-      return kPaletteWhite;
-    case ItemColor.white:
-      return paletteGreyColor2;
-    case ItemColor.pink:
-      return kPaletteWhite; 
-    case ItemColor.grey:
-      return kPaletteWhite;
-    default:
-      return paletteGreyColor2;
   }
 }
 
@@ -111,7 +79,7 @@ String getDisplayTextForItemSize(ItemSize itemSize) {
 }
 
 class StockItem {
-  final ItemColor color;
+  final String color;
   final ItemSize size;
   int quantity;
 
@@ -123,20 +91,31 @@ class StockItem {
 
   Map<String, dynamic> toMap() {
     return {
-      'color': color?.index,
+      'color': color,
       'size': size?.index,
       'quantity': quantity,
     };
   }
 
+  // TOREMOVE: Update color value type from int to String in order's stock item in Firestore first then remove this indexColorMap
+  static Map indexColorMap = {
+    "0": "black",
+    "1": "brown",
+    "2": "white",
+    "3": "pink",
+    "4": "grey",
+  };
+
   StockItem.fromMap(Map<String, dynamic> map)
-      : color = map['color'] != null ? ItemColor.values[map['color']] : null,
+    // TOREMOVE: Remove "map['color'] is int" condition once color value type gets updated from int to String in order's stock item in Firestore
+      : color = map['color'] is int 
+        ? indexColorMap[map['color'].toString()] : map['color'] is String ? map['color'] : null,
         size = map['size'] != null ? ItemSize.values[map['size']] : null,
         quantity = map['quantity'];
 }
 
 class StockIdentifier {
-  final ItemColor color;
+  final String color;
   final ItemSize size;
 
   StockIdentifier({

--- a/lib/screens/admin_home_page.dart
+++ b/lib/screens/admin_home_page.dart
@@ -35,7 +35,6 @@ class _AdminHomePageState extends State<AdminHomePage> {
   final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
 
   OrderFilterButtons selectedOrderButton = OrderFilterButtons.all;
-
   OrderStatus orderStatusToFilter = OrderStatus.all;
 
   _saveDeviceToken() async {

--- a/lib/screens/admin_new_color_page.dart
+++ b/lib/screens/admin_new_color_page.dart
@@ -1,0 +1,281 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
+
+import 'package:badiup/colors.dart';
+import 'package:badiup/constants.dart' as constants;
+import 'package:badiup/models/custom_color_model.dart';
+
+class AdminNewColorPage extends StatefulWidget {
+  @override
+  _NewColorPageState createState() {
+    return _NewColorPageState();
+  }
+}
+
+class _NewColorPageState extends State<AdminNewColorPage> {
+  final _nameEditingController = TextEditingController();
+  final _labelEditingController = TextEditingController();
+  Color _currentColor = Colors.white;
+  String _selectedTextColor = "grey";
+
+  void changeColor(Color color) => setState(() => _currentColor = color);
+  String extractHexFromColor(Color color) =>
+      color.toString().split('(')[1].split(')')[0];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('色の追加'),
+        centerTitle: true,
+        leading: new IconButton(
+          icon: new Icon(Icons.arrow_back_ios),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+      ),
+      body: _buildBody(context),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    var widgetList = <Widget>[
+      _buildColorListFromDB(context),
+      _buildNameTextField(),
+      _buildLabelTextField(),
+      _buildTextColorDropdown(),
+      _buildHexButtonField(),
+      _buildSubmitButton(),
+    ];
+
+    return Stack(
+      children: widgetList,
+    );
+  }
+
+  Widget _buildNameTextField() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16.0, 20.0, 16.0, 0.0),
+      child: TextFormField(
+        controller: _nameEditingController,
+        decoration: InputDecoration(
+          labelText: 'Name',
+        ),
+        maxLength: 10,
+        validator: (value) {
+          if (value.isEmpty) {
+            return 'Nameが入力されていません';
+          }
+          return null;
+        },
+      ),
+    );
+  }
+
+  Widget _buildHexButtonField() {
+    var _textStyle = TextStyle(
+      color: _currentColor,
+      fontSize: 18,
+      fontWeight: FontWeight.w600,
+    );
+
+    return Padding(
+        padding: const EdgeInsets.fromLTRB(16.0, 180.0, 16.0, 0.0),
+        child: Row(children: <Widget>[
+          RaisedButton(
+            elevation: 3.0,
+            onPressed: () {
+              showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  return AlertDialog(
+                    titlePadding: const EdgeInsets.all(0.0),
+                    contentPadding: const EdgeInsets.all(0.0),
+                    content: SingleChildScrollView(
+                      child: ColorPicker(
+                        pickerColor: _currentColor,
+                        onColorChanged: changeColor,
+                        colorPickerWidth: 300.0,
+                        pickerAreaHeightPercent: 0.7,
+                        enableAlpha: true,
+                        displayThumbColor: true,
+                        showLabel: true,
+                        paletteType: PaletteType.hsv,
+                        pickerAreaBorderRadius: const BorderRadius.only(
+                          topLeft: const Radius.circular(2.0),
+                          topRight: const Radius.circular(2.0),
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+            child: Text("色を選択"),
+            color: _currentColor,
+            textColor: useWhiteForeground(_currentColor)
+                ? const Color(0xffffffff)
+                : const Color(0xff000000),
+          ),
+          Padding(
+              padding: const EdgeInsets.all(16.0),
+              child:
+                  Text(extractHexFromColor(_currentColor), style: _textStyle))
+        ]));
+  }
+
+  Widget _buildLabelTextField() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16.0, 100.0, 16.0, 60.0),
+      child: TextFormField(
+        controller: _labelEditingController,
+        decoration: InputDecoration(
+          labelText: 'Label',
+        ),
+        maxLength: 10,
+        validator: (value) {
+          if (value.isEmpty) {
+            return 'Labelが入力されていません';
+          }
+          return null;
+        },
+      ),
+    );
+  }
+
+  Widget _buildTextColorDropdown() {
+    var _textStyle = TextStyle(
+      color: paletteBlackColor,
+      fontSize: 16,
+      fontWeight: FontWeight.w600,
+    );
+
+    List<String> _items = ["grey", "white"];
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16.0, 250.0, 16.0, 60.0),
+      child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              "Text Color",
+              style: TextStyle(
+                color: paletteBlackColor,
+                fontSize: 20
+              ),
+            ),
+            DropdownButton<String>(
+              isExpanded: true,
+              value: _selectedTextColor,
+              icon: Icon(Icons.keyboard_arrow_down, color: paletteBlackColor),
+              iconSize: 32,
+              elevation: 2,
+              style: _textStyle,
+              underline: Container(height: 0, color: paletteBlackColor),
+              onChanged: (String newValue) {
+                setState(() {
+                  _selectedTextColor = newValue;
+                });
+              },
+              items: _items.map((String item) {
+                return DropdownMenuItem(
+                  value: item,
+                  child: Text(
+                    item,
+                    style: item == _selectedTextColor
+                        ? TextStyle(fontWeight: FontWeight.bold)
+                        : TextStyle(fontWeight: FontWeight.normal),
+                  ),
+                );
+              }).toList(),
+            ),
+          ]),
+    );
+  }
+
+  Widget _buildSubmitButton() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16.0, 330.0, 16.0, 60.0),
+      child: RaisedButton(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(5.0),
+        ),
+        onPressed: () async {
+          //TODO: Add validation to all form components
+          await _submitForm();
+          _nameEditingController.clear();
+          _labelEditingController.clear();
+          changeColor(Color(0xffffffff));
+          setState(() {
+            _selectedTextColor = "grey";
+          });
+          Navigator.pop(context);
+        },
+        child: Text('追加する'),
+      ),
+    );
+  }
+
+  CustomColor _buildColorModel() {
+    final _color = CustomColor(
+      name: _nameEditingController.text,
+      hex: extractHexFromColor(_currentColor),
+      label: _labelEditingController.text,
+      textColor: _selectedTextColor,
+    );
+    return _color;
+  }
+
+  Future<void> _submitForm() async {
+    CustomColor _colorModel = _buildColorModel();
+    await Firestore.instance
+        .collection(constants.DBCollections.colors)
+        .add(_colorModel.toMap());
+  }
+
+  Widget _buildColorListFromDB(BuildContext context) {
+    return StreamBuilder<QuerySnapshot>(
+      stream: Firestore.instance
+          .collection(constants.DBCollections.colors)
+          .snapshots(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) return LinearProgressIndicator();
+
+        return _buildList(context, snapshot.data.documents);
+      },
+    );
+  }
+
+  Widget _buildList(BuildContext context, List<DocumentSnapshot> snapshot) {
+    return ListView(
+      padding: const EdgeInsets.only(top: 400.0),
+      children: snapshot.map((data) => _buildListItem(context, data)).toList(),
+    );
+  }
+
+  Widget _buildListItem(BuildContext context, DocumentSnapshot data) {
+    final color = CustomColor.fromSnapshot(data);
+    var textColorStyle = color.textColor == "grey"
+        ? TextStyle(color: paletteGreyColor2)
+        : TextStyle(color: kPaletteWhite);
+
+    return Padding(
+      key: ValueKey(color.name),
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: Colors.grey),
+          borderRadius: BorderRadius.circular(5.0),
+        ),
+        child: ListTile(
+          leading: Text(color.name, style: getTextStyleWithHex(color.hex)),
+          title: Text(color.label, style: getTextStyleWithHex(color.hex)),
+          subtitle: Text(color.hex, style: getTextStyleWithHex(color.hex)),
+          trailing: Text(color.textColor, style: textColorStyle),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/product_detail.dart
+++ b/lib/widgets/product_detail.dart
@@ -22,7 +22,7 @@ class ProductDetail extends StatefulWidget {
   }) : super(key: key);
 
   final String productDocumentId;
-  final ItemColor selectedItemColor;
+  final String selectedItemColor;
   final ItemSize selectedItemSize;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   image_cropper: ^1.1.0
   image_picker: 0.6.0+17
   transparent_image: ^1.0.0
+  flutter_colorpicker: ^0.3.4
 
   uuid: any
   path_provider: ^1.4.4


### PR DESCRIPTION
In the course of handling to add new colors dynamically from UI https://github.com/GospelAid/badiup/issues/162, I first added a functionality to add dynamic `Color` to related pages on `Admin` side.

- I'll apply the same change to `Customer` side after this PR gets merged.

**1. Add new color dynamically**
![](http://g.recordit.co/wfy4ayWUfd.gif)

**2.Refer to the new color after registration**
![](http://g.recordit.co/hbg1hRFmss.gif)

---
TBD: There is no fixed design for the screen to add new color. The current implementation is temporary added.

![admin-new-color](https://user-images.githubusercontent.com/28984604/81500968-919d8200-9310-11ea-8fad-946cb52d3e7d.png)
